### PR TITLE
Added buttons for endorsing/unendorsing topic

### DIFF
--- a/templates/partials/category/tools.tpl
+++ b/templates/partials/category/tools.tpl
@@ -35,12 +35,12 @@
 
 		<li>
 			<a component="topic/endorse" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2" role="menuitem">
-				<i class="fa fa-fw fa-lock text-secondary"></i> [[topic:thread-tools.endorse]]
+				<i class="fa fa-fw fa-thumbs-up text-secondary"></i> [[topic:thread-tools.endorse]]
 			</a>
 		</li>
 		<li>
 			<a component="topic/unendorse" href="#" class="hidden dropdown-item rounded-1 d-flex align-items-center gap-2" role="menuitem">
-				<i class="fa fa-fw fa-unlock text-secondary"></i> [[topic:thread-tools.unendorse]]
+				<i class="fa fa-fw fa-thumbs-down fa-rotate-90 text-secondary"></i> [[topic:thread-tools.unendorse]]
 			</a>
 		</li>
 

--- a/templates/partials/category/tools.tpl
+++ b/templates/partials/category/tools.tpl
@@ -33,6 +33,17 @@
 			</a>
 		</li>
 
+		<li>
+			<a component="topic/endorse" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2" role="menuitem">
+				<i class="fa fa-fw fa-lock text-secondary"></i> [[topic:thread-tools.endorse]]
+			</a>
+		</li>
+		<li>
+			<a component="topic/unendorse" href="#" class="hidden dropdown-item rounded-1 d-flex align-items-center gap-2" role="menuitem">
+				<i class="fa fa-fw fa-unlock text-secondary"></i> [[topic:thread-tools.unendorse]]
+			</a>
+		</li>
+
 		<li class="dropdown-divider"></li>
 
 		<li>

--- a/templates/partials/topic/topic-menu-list.tpl
+++ b/templates/partials/topic/topic-menu-list.tpl
@@ -16,11 +16,11 @@
 </li>
 
 <li {{{ if endorsed }}}hidden{{{ end }}}>
-	<a component="topic/endorse" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2 {{{ if endorsed }}}hidden{{{ end }}}" role="menuitem"><i class="fa fa-fw fa-lock text-secondary"></i> Endorse Topic </a>
+	<a component="topic/endorse" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2 {{{ if endorsed }}}hidden{{{ end }}}" role="menuitem"><i class="fa fa-fw fa-thumbs-up text-secondary"></i> Endorse Topic </a>
 </li>
 
 <li {{{ if !endorsed }}}hidden{{{ end }}}>
-	<a component="topic/unendorse" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2 {{{ if !endorsed }}}hidden{{{ end }}}" role="menuitem"><i class="fa fa-fw fa-unlock text-secondary"></i> Unendorse Topic </a>
+	<a component="topic/unendorse" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2 {{{ if !endorsed }}}hidden{{{ end }}}" role="menuitem"><i class="fa fa-fw fa-thumbs-down fa-rotate-90 text-secondary"></i> Unendorse Topic </a>
 </li>
 
 <li>

--- a/templates/partials/topic/topic-menu-list.tpl
+++ b/templates/partials/topic/topic-menu-list.tpl
@@ -15,12 +15,12 @@
 	<a component="topic/unpin" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2 {{{ if !pinned }}}hidden{{{ end }}}" role="menuitem"><i class="fa fa-fw fa-thumb-tack fa-rotate-90 text-secondary"></i> [[topic:thread-tools.unpin]]</a>
 </li>
 
-<li>
-	<a component="topic/tag" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2" role="menuitem"><i class="fa fa-fw fa-thumbs-up text-secondary"></i> Endorse Topic </a>
+<li {{{ if endorsed }}}hidden{{{ end }}}>
+	<a component="topic/endorse" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2 {{{ if endorsed }}}hidden{{{ end }}}" role="menuitem"><i class="fa fa-fw fa-lock text-secondary"></i> Endorse Topic </a>
 </li>
 
-<li>
-	<a component="topic/tag" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2" role="menuitem"><i class="fa fa-fw fa-thumbs-down text-secondary"></i> Unendorse Topic </a>
+<li {{{ if !endorsed }}}hidden{{{ end }}}>
+	<a component="topic/unendorse" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2 {{{ if !endorsed }}}hidden{{{ end }}}" role="menuitem"><i class="fa fa-fw fa-unlock text-secondary"></i> Unendorse Topic </a>
 </li>
 
 <li>

--- a/templates/partials/topic/topic-menu-list.tpl
+++ b/templates/partials/topic/topic-menu-list.tpl
@@ -16,6 +16,14 @@
 </li>
 
 <li>
+	<a component="topic/tag" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2" role="menuitem"><i class="fa fa-fw fa-thumbs-up text-secondary"></i> Endorse Topic </a>
+</li>
+
+<li>
+	<a component="topic/tag" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2" role="menuitem"><i class="fa fa-fw fa-thumbs-down text-secondary"></i> Unendorse Topic </a>
+</li>
+
+<li>
 	<a component="topic/move" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2" role="menuitem"><i class="fa fa-fw fa-arrows text-secondary"></i> [[topic:thread-tools.move]]</a>
 </li>
 

--- a/templates/partials/topics_list.tpl
+++ b/templates/partials/topics_list.tpl
@@ -45,7 +45,7 @@
 						<span>[[topic:locked]]</span>
 					</span>
 					<span component="topic/endorsed" class="badge border border-gray-300 text-body {{{ if !./endorsed }}}hidden{{{ end }}}">
-						<i class="fa fa-lock"></i>
+						<i class="fa fa-thumbs-up"></i>
 						<span>[[topic:endorsed]]</span>
 					</span>
 					<span component="topic/moved" class="badge border border-gray-300 text-body {{{ if !./oldCid }}}hidden{{{ end }}}">

--- a/templates/partials/topics_list.tpl
+++ b/templates/partials/topics_list.tpl
@@ -44,6 +44,10 @@
 						<i class="fa fa-lock"></i>
 						<span>[[topic:locked]]</span>
 					</span>
+					<span component="topic/endorsed" class="badge border border-gray-300 text-body {{{ if !./endorsed }}}hidden{{{ end }}}">
+						<i class="fa fa-lock"></i>
+						<span>[[topic:endorsed]]</span>
+					</span>
 					<span component="topic/moved" class="badge border border-gray-300 text-body {{{ if !./oldCid }}}hidden{{{ end }}}">
 						<i class="fa fa-arrow-circle-right"></i>
 						<span>[[topic:moved]]</span>

--- a/templates/topic.tpl
+++ b/templates/topic.tpl
@@ -29,7 +29,7 @@
 				</h1>
 
 				<div class="topic-info d-flex gap-2 align-items-center flex-wrap {{{ if config.theme.centerHeaderElements }}}justify-content-center{{{ end }}}">
-					<span component="topic/labels" class="d-flex gap-2 {{{ if (!scheduled && (!pinned && (!locked && (!oldCid && !icons.length)))) }}}hidden{{{ end }}}">
+					<span component="topic/labels" class="d-flex gap-2 {{{ if (!scheduled && (!pinned && (!locked && (!endorsed && (!oldCid && !icons.length))))) }}}hidden{{{ end }}}">
 						<span component="topic/scheduled" class="badge badge border border-gray-300 text-body {{{ if !scheduled }}}hidden{{{ end }}}">
 							<i class="fa fa-clock-o"></i> [[topic:scheduled]]
 						</span>
@@ -38,6 +38,9 @@
 						</span>
 						<span component="topic/locked" class="badge badge border border-gray-300 text-body {{{ if !locked }}}hidden{{{ end }}}">
 							<i class="fa fa-lock"></i> [[topic:locked]]
+						</span>
+						<span component="topic/endorsed" class="badge badge border border-gray-300 text-body {{{ if !endorsed }}}hidden{{{ end }}}">
+							<i class="fa fa-lock"></i> [[topic:endorsed]]
 						</span>
 						<a component="topic/moved" href="{config.relative_path}/category/{oldCid}" class="badge badge border border-gray-300 text-body text-decoration-none {{{ if !oldCid }}}hidden{{{ end }}}">
 							<i class="fa fa-arrow-circle-right"></i> {{{ if privileges.isAdminOrMod }}}[[topic:moved-from, {oldCategory.name}]]{{{ else }}}[[topic:moved]]{{{ end }}}

--- a/templates/topic.tpl
+++ b/templates/topic.tpl
@@ -40,7 +40,7 @@
 							<i class="fa fa-lock"></i> [[topic:locked]]
 						</span>
 						<span component="topic/endorsed" class="badge badge border border-gray-300 text-body {{{ if !endorsed }}}hidden{{{ end }}}">
-							<i class="fa fa-lock"></i> [[topic:endorsed]]
+							<i class="fa fa-thumbs-up"></i> [[topic:endorsed]]
 						</span>
 						<a component="topic/moved" href="{config.relative_path}/category/{oldCid}" class="badge badge border border-gray-300 text-body text-decoration-none {{{ if !oldCid }}}hidden{{{ end }}}">
 							<i class="fa fa-arrow-circle-right"></i> {{{ if privileges.isAdminOrMod }}}[[topic:moved-from, {oldCategory.name}]]{{{ else }}}[[topic:moved]]{{{ end }}}


### PR DESCRIPTION
Added buttons for both endorsing and unendorsing a topic. This was done by modifying templates/partials/topic/topic-menu-list.tpl file, which added these buttons alongside the other buttons in the Topic Tools dropdown menu. 

Currently the buttons don't work (they copy the functionality pinning/unpinning a topic), though I will connect the buttons to backend logic soon.

This branch resolves [#10](https://github.com/CMU-313/nodebb-f24-team-software-stars/issues/10) on our main repo and is part of our Sprint 2 milestone.