### PR TITLE
Added styling and UI componenet for labeling topic answered by admin

### DIFF
--- a/templates/topic.tpl
+++ b/templates/topic.tpl
@@ -21,6 +21,25 @@
 		{{{ if author.userslug }}}<meta itemprop="url" content="{config.relative_path}/user/{author.userslug}">{{{ end }}}
 	</div>
 
+	<style>
+    .blue-box {
+        border: 2px solid #007BFF;
+        background-color: #E9F7FE;
+        padding: 10px;
+        border-radius: 5px;
+        color: #007BFF;
+    }
+	</style>
+
+	<div>
+		{{{if! answered}}}
+			<div class="blue-box">
+				<p>The question has been answered by a professor!</p>
+			</div>
+		{{{end}}}
+	</div>
+
+
 	<div class="d-flex flex-column gap-3">
 		<div class="d-flex flex-wrap">
 			<div class="d-flex flex-column gap-3 flex-grow-1">


### PR DESCRIPTION
Added UI component for when an admin has answered a topic to appear when an admin has added a post to a topic. This was done by modifying `templates/topic.tpl`, which uses the "answered" attribute from the database to check whether the text should be displayed. Also, with this logic, when a topic has not been responded to by a professor, nothing appears.
Also added styling for the text within the same `templates/topic.tpl`.

<img width="1114" alt="image" src="https://github.com/user-attachments/assets/6e9ec65d-0e62-4cb9-a68f-e41c4dc5b4f6">

This resolves [#34](https://github.com/CMU-313/nodebb-f24-team-software-stars/issues/34) in our main repo and is part of our Sprint 2 milestone.